### PR TITLE
Fix the problem of incorrect  role template for appstore

### DIFF
--- a/src/main/resources/extensions/store-role-template.yaml
+++ b/src/main/resources/extensions/store-role-template.yaml
@@ -13,6 +13,6 @@ metadata:
       [ "role-template-manage-plugins", "role-template-manage-themes" ]
 rules:
   - apiGroups: [""]
-    resources: ["secret"]
+    resources: ["secrets"]
     resourceNames: ["halo-run-app-store-pat-secret"]
     verbs: ["create", "update", "get", "delete"]


### PR DESCRIPTION
This PR fixes the incorrect rule configuration of role template of app store.

/kind bug

```release-note
修复应用管理角色失效的问题
```